### PR TITLE
Allow space before async arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = {
         'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
         'semi': 'error',
         'space-before-blocks': 'error',
-        'space-before-function-paren': ['error', 'never'],
+        'space-before-function-paren': ['error', {'anonymous': 'never', 'named': 'never', 'asyncArrow': 'always'}],
         'space-in-parens': ['error', 'never'],
         'space-infix-ops': 'error',
         'space-unary-ops': 'error',


### PR DESCRIPTION
```js
// Сейчас необходимо писать так:
async() => 'foo'

// Нужно будет писать так:
async () => 'foo'
```