### PR TITLE
feat: add 'ecmaFeatures.experimentalObjectRestSpread' rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ module.exports = {
     },
     'parserOptions': {
         sourceType: 'module',
-        ecmaVersion: 8
+        ecmaVersion: 8,
+        ecmaFeatures: {
+            experimentalObjectRestSpread:  true
+        }
     }
 }


### PR DESCRIPTION
Чтобы линтер не ругался на 

```js
{obj1, ...obj2}
```