### PR TITLE
Remove experimentalObjectRestSpread

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,9 +48,6 @@ module.exports = {
     },
     'parserOptions': {
         sourceType: 'module',
-        ecmaVersion: 8,
-        ecmaFeatures: {
-            experimentalObjectRestSpread:  true
-        }
+        ecmaVersion: 2018
     }
 }


### PR DESCRIPTION
Option experimentalObjectRestSpread is deprecated in eslint 5 in favor of ecmaVersion: 2018, and is no-op since eslint 6
https://eslint.org/docs/user-guide/migrating-to-6.0.0#the-deprecated-experimentalobjectrestspread-option-has-been-removed